### PR TITLE
feat(config): increase budgets for component styles

### DIFF
--- a/pawtect-frontend/angular.json
+++ b/pawtect-frontend/angular.json
@@ -42,13 +42,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "10kb",
+                  "maximumError": "20kb"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
Increased the maximum budget for component styles in angular.json to accommodate larger SCSS files. This change addresses the budget errors encountered during the build process.

- Increased maximumWarning for nyComponentStyle to 10kb
- Increased maximumError for nyComponentStyle to 20kb